### PR TITLE
Fix Error if only one Private Data

### DIFF
--- a/Payline/PaylineResult.php
+++ b/Payline/PaylineResult.php
@@ -63,6 +63,22 @@ class PaylineResult
         $this->shortMessage = $this->resultHash['result']['shortMessage'];
         $this->longMessage = $this->resultHash['result']['longMessage'];
         if (!empty($this->resultHash['privateDataList']['privateData'])) {
+            // With only one private data, ['privateDataList']['privateData'] is not an array but the data itself.
+            // Several private data:
+            // [
+            //     ['key' => 'foo', 'value' => 'bar'],
+            //     ['key' => 'baz', 'value' => '123456'],
+            // ]
+            // One private data:
+            // [
+            //     'key' => 'foo',
+            //     'value' => 'bar',
+            // ]
+            // @see https://github.com/lolautruche/LolautruchePaylineBundle/issues/1
+            if (isset($this->resultHash['privateDataList']['privateData']['key'])) {
+                $this->resultHash['privateDataList']['privateData'] = [$this->resultHash['privateDataList']['privateData']];
+            }
+
             foreach ($this->resultHash['privateDataList']['privateData'] as $data) {
                 $this->privateData[$data['key']] = $data['value'];
             }

--- a/Tests/Payline/PaylineResultTest.php
+++ b/Tests/Payline/PaylineResultTest.php
@@ -224,13 +224,18 @@ class PaylineResultTest extends PHPUnit_Framework_TestCase
     {
         return [
             [
-                [['key' => 'foo', 'value' => 'bar']],
+                // With only one private data, ['privateDataList']['privateData'] is not an array of privateData but the data itself.
+                // @see https://github.com/lolautruche/LolautruchePaylineBundle/issues/1
+                ['key' => 'foo', 'value' => 'bar'],
                 'foo',
                 null,
                 'bar',
             ],
             [
-                [['key' => 'foo', 'value' => 'bar']],
+                [
+                    ['key' => 'foo', 'value' => 'bar'],
+                    ['key' => 'baz', 'value' => '123456'],
+                ],
                 'biz',
                 'default_value',
                 'default_value',


### PR DESCRIPTION
When adding only one private data, result returned by Payline webservice won't contain `privateData`
as an array of data, but the data itself.

With only one private data, `['privateDataList']['privateData']` is not an
array but the data itself.

Several private data:
```
[
    ['key' => 'foo', 'value' => 'bar'],
    ['key' => 'baz', 'value' => '123456'],
]
```

One private data:
```
[
    'key' => 'foo',
    'value' => 'bar',
]
```

Fix #1