### PR TITLE
Fix auth token name

### DIFF
--- a/Controller/PaylineController.php
+++ b/Controller/PaylineController.php
@@ -47,6 +47,13 @@ class PaylineController
      */
     private $defaultErrorUrl;
 
+    /**
+     * PaylineController constructor.
+     * @param EventDispatcherInterface $eventDispatcher
+     * @param WebGatewayInterface      $payline
+     * @param string                   $defaultConfirmationUrl
+     * @param string                   $defaultErrorUrl
+     */
     public function __construct(EventDispatcherInterface $eventDispatcher, WebGatewayInterface $payline, $defaultConfirmationUrl, $defaultErrorUrl)
     {
         $this->eventDispatcher = $eventDispatcher;
@@ -55,18 +62,26 @@ class PaylineController
         $this->defaultErrorUrl = $defaultErrorUrl;
     }
 
+    /**
+     * @param Request $request
+     * @return Response
+     */
     public function paymentNotificationAction(Request $request)
     {
-        $result = $this->payline->verifyWebTransaction($request->get('token'));
+        $result = $this->payline->verifyWebTransaction($request->get('paylinetoken', $request->get('token')));
         $event = new PaymentNotificationEvent($result);
         $this->eventDispatcher->dispatch(PaylineEvents::ON_NOTIFICATION, $event);
 
         return new Response('OK');
     }
 
+    /**
+     * @param Request $request
+     * @return RedirectResponse|Response
+     */
     public function backToShopAction(Request $request)
     {
-        $result = $this->payline->verifyWebTransaction($request->get('token'));
+        $result = $this->payline->verifyWebTransaction($request->get('paylinetoken', $request->get('token')));
         $event = new PaymentNotificationEvent($result);
         $this->eventDispatcher->dispatch(PaylineEvents::ON_BACK_TO_SHOP, $event);
 

--- a/Tests/Controller/PaylineControllerTest.php
+++ b/Tests/Controller/PaylineControllerTest.php
@@ -47,7 +47,7 @@ class PaylineControllerTest extends PHPUnit_Framework_TestCase
     {
         $token = md5(microtime(true));
         $request = new Request();
-        $request->query->set('token', $token);
+        $request->query->set('paylinetoken', $token);
         $result = new PaylineResult([]);
         $this->paylineGateway
             ->expects($this->once())
@@ -68,7 +68,7 @@ class PaylineControllerTest extends PHPUnit_Framework_TestCase
     {
         $token = md5(microtime(true));
         $request = new Request();
-        $request->query->set('token', $token);
+        $request->query->set('paylinetoken', $token);
         $result = new PaylineResult([
             'result' => [
                 'code' => PaylineResult::CODE_TRANSACTION_APPROVED,
@@ -97,7 +97,7 @@ class PaylineControllerTest extends PHPUnit_Framework_TestCase
     {
         $token = md5(microtime(true));
         $request = new Request();
-        $request->query->set('token', $token);
+        $request->query->set('paylinetoken', $token);
         $result = new PaylineResult([
             'result' => [
                 'code' => PaylineResult::CODE_INTERNAL_ERROR,
@@ -126,7 +126,7 @@ class PaylineControllerTest extends PHPUnit_Framework_TestCase
     {
         $token = md5(microtime(true));
         $request = new Request();
-        $request->query->set('token', $token);
+        $request->query->set('paylinetoken', $token);
         $result = new PaylineResult([
             'result' => [
                 'code' => PaylineResult::CODE_TRANSACTION_APPROVED,


### PR DESCRIPTION
The auth token in get parameters is now **paylinetoken** instead of **token**.
Check the payline support page : https://support.payline.com/hc/fr/articles/217689337-Pages-de-paiement-int%C3%A9gr%C3%A9es#Pagesdepaiement-Modelightbox#Pagesdepaiement-Modeintégré